### PR TITLE
Don't downsample observed position, but avoid plotting redundant points.

### DIFF
--- a/test-gui/src/package/view-decoded-linear-position-plot/DecodedLinearPositionDownsampling.ts
+++ b/test-gui/src/package/view-decoded-linear-position-plot/DecodedLinearPositionDownsampling.ts
@@ -1,4 +1,3 @@
-import { median } from 'mathjs'
 
 // We will potentially be doing this a lot, and supposedly the good old for-loop is more
 // performant than doing array-copy slicing and/or fancy reduce tricks.
@@ -97,24 +96,6 @@ export const getDownsampledRange = (scaleFactor: number, firstSelected: number, 
         downsampledStart: Math.floor(firstSelected / scaleFactor),
         downsampledEnd: Math.ceil(lastSelected / scaleFactor)
     }
-}
-
-
-// TODO: Make sure we're using typed arrays for positions array.
-export const downsampleObservedPositions = (scaleFactor: number, positions: number[]): number[] | undefined => {
-    if (positions === undefined) return undefined
-    if (scaleFactor < 1) {
-        console.warn(`Attempt to use scale factor of less than 1 in downsampling observed position. Don't do that.`)
-        return undefined
-    }
-    if (scaleFactor === 1) {
-        return positions
-    }
-    const p: number[] = Array.from({length: Math.ceil(positions.length / scaleFactor)})
-    p.forEach((value, index) => {
-        p[index] = median(positions.slice(index * scaleFactor, (index + 1) * scaleFactor))
-    })
-    return p
 }
 
 


### PR DESCRIPTION
This PR improves display of observed position overlay by avoiding downsampling.

It is desirable to avoid downsampling both because downsampling the observed position is an expensive operation, and because downsampling makes it hard to distinguish between points that should and should not be joined. (The linearized position space includes null regions, to which no part of the track would be projected. When the animal's observed position crosses one of these regions, we want to avoid connecting those points with a line, because it would suggest that the animal was observed to move through a nonexistent part of the track. We detect these discontinuous areas by looking for points with a linear-observed-position delta greater than 0.5% of the track width--essentially skipping over areas where the animal would have violated the "speed limit". This works at full-resolution or low-factor downsampling because the time points are sufficiently close that the displacement per downsampled time point is still within this 'speed limit', but at higher levels of downsampling, the magnitude of plausible changes in displacement overlaps with the displacement that would be required to cross a null region: the 6-mm null region could not be crossed between time points when each time point represents 2 ms, but that's an entirely plausible displacement at 729x downsampling when subsequent data points represent 1.5 seconds' worth of movement.)

Unfortunately, using the full-resolution data for observed position leads to degraded drawing performance, because O(1 million) time points mapped onto O(1000) pixels leads to a lot of overlapping drawing. To correct for this, I've implemented a rule that avoids plotting more than one observation per pixel. With this in place, there is no noticeable difference in panning performance when the position overlay is on vs. when it is off.