### PR TITLE
Decoded position realignment

### DIFF
--- a/test-gui/devel/deploy_dev.sh
+++ b/test-gui/devel/deploy_dev.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-TARGET=gs://figurl/franklab-views-dev1g
+TARGET=gs://figurl/franklab-views-dev1k
 
 yarn build
 gsutil -m cp -R ./build/* $TARGET/

--- a/test-gui/src/package/view-decoded-linear-position-plot/DecodedLinearPositionPlotView.tsx
+++ b/test-gui/src/package/view-decoded-linear-position-plot/DecodedLinearPositionPlotView.tsx
@@ -51,7 +51,7 @@ const DecodedLinearPositionPlotView: FunctionComponent<DecodedLinearPositionProp
     const endTimeSec = _startTimeSec + frameBounds.length / _samplingFrequencyHz
     useRecordingSelectionTimeInitialization(_startTimeSec, endTimeSec)
     const { visibleTimeStartSeconds, visibleTimeEndSeconds } = useTimeRange()
-    const [showObservedPositionsOverlay, setShowObservedPositionsOverlay] = useState<boolean>(false)
+    const [showObservedPositionsOverlay, setShowObservedPositionsOverlay] = useState<boolean>(true)
     const { colorStyles, contrastStyle } = useMemo(() => getColorStyles(DEFAULT_COLOR_MAP_CHOICE), [])
 
     const {firstFrame, lastFrame} = getVisibleFrames(_startTimeSec, _samplingFrequencyHz, frameBounds.length, visibleTimeStartSeconds, visibleTimeEndSeconds)

--- a/test-gui/src/package/view-decoded-linear-position-plot/DecodedLinearPositionPlotView.tsx
+++ b/test-gui/src/package/view-decoded-linear-position-plot/DecodedLinearPositionPlotView.tsx
@@ -76,9 +76,9 @@ const DecodedLinearPositionPlotView: FunctionComponent<DecodedLinearPositionProp
         return canvas
     }, [])
 
-    const { canvasPositions, targetHeight } = usePositions(MAX_OFFSCREEN_CANVAS_HEIGHT, positionsKey)
+    const { canvasPositions, pixelBinWidth, targetHeight } = usePositions(MAX_OFFSCREEN_CANVAS_HEIGHT, positionsKey)
     const canvasTargetWidth = useMemo(() => Math.min(MAX_OFFSCREEN_CANVAS_WIDTH, sampledData.downsampledTimes.length), [sampledData.downsampledTimes.length])
-    const painter = useOffscreenPainter(colorStyles, targetHeight, canvasPositions)
+    const painter = useOffscreenPainter(colorStyles, targetHeight, pixelBinWidth, canvasPositions)
     const offscreenRenderProps = useMemo(() => {
         const props: OffscreenRenderProps = {
             canvas,
@@ -113,10 +113,10 @@ const DecodedLinearPositionPlotView: FunctionComponent<DecodedLinearPositionProp
             context.beginPath()
             visibleObserved.forEach((v, i) => {
                 const x = i * xStepSize
-                const y = panelHeight * v
+                const y = (panelHeight * v) + 2
                 const deltaY = Math.abs(Math.floor(y) - Math.floor(lastY))
                 if ((Math.floor(lastX) !== Math.floor(x)) || (Math.floor(y) !== Math.floor(lastY))) {
-                    deltaY > (verticalEpsilonPx) ? context.moveTo(x, panelHeight * v) : context.lineTo(x, panelHeight * v)
+                    deltaY > (verticalEpsilonPx) ? context.moveTo(x, y) : context.lineTo(x, y)
                 }
                 lastX = x
                 lastY = y


### PR DESCRIPTION
This does three things:

- Adjust the decoded-position bins to recognize that the position in the data is supposed to be the center of the range, rather than the top of the range.
  - Accordingly, treat the first position as half the bin width (since it's halfway between 0 and the end of the first bin) and use that value to compute the appropriate width to draw for all other bins.
  - Note that this isn't *strictly* accurate, as Eric told me it's theoretically possible that the first position might not be a bin that starts at 0, and it's possible for there to be small variations in the bin widths on different branches of the track. We've agreed that we can avoid worrying about those possibilities for now.
- Bump the observed-position overlay down by 2 pixels so it doesn't run into the top of the overall window so much.
- Turn observed-position overlay on by default

https://figurl.org/f?v=gs://figurl/franklab-views-dev1k&d=sha1://5ce6bd6dfce3932d2bde1a79b2a51ef39fab8e14&label=03f1-acausal-posterior&s={} includes all these changes except for the last one (which I didn't bother redeploying, as it's just changing the default of the `useState` hook to `true` instead of `false`; I have confirmed that it still works.)