### PR TITLE
Accommodate 1d decode datasets with shorter duration than synced time series.

### DIFF
--- a/test-gui/src/package/view-decoded-linear-position-plot/DecodedLinearPositionDrawing.ts
+++ b/test-gui/src/package/view-decoded-linear-position-plot/DecodedLinearPositionDrawing.ts
@@ -25,6 +25,7 @@ export type OffscreenRenderProps = {
     scale: number
     downsampledRangeStart: number
     downsampledRangeEnd: number
+    downsampledRangeMax: number
 }
 // Given a Canvas with stuff drawn on it and a data set, and a desired range of data from the data set,
 // return the x-coordinate pixel range in the offscreen canvas that contains the requested data range.
@@ -33,7 +34,7 @@ export const useOffscreenCanvasRange = (props: OffscreenRenderProps): [number, n
     const contentsEnd = useRef<number>(0)
     const currentScale = useRef<number>(0)
     const currentPainter = useRef<OffscreenPainter>()
-    const { canvas, canvasTargetWidth, canvasTargetHeight, painter, scale, sampledData, downsampledRangeStart, downsampledRangeEnd } = props
+    const { canvas, canvasTargetWidth, canvasTargetHeight, painter, scale, sampledData, downsampledRangeStart, downsampledRangeEnd, downsampledRangeMax } = props
 
     if (canvas === undefined) return [0, 0]
 
@@ -62,10 +63,8 @@ export const useOffscreenCanvasRange = (props: OffscreenRenderProps): [number, n
     }
 
     console.assert(contentsStart.current <= contentsEnd.current)
-    if ((downsampledRangeEnd - downsampledRangeStart) > (canvas.width)) {
-        // jfm turned this error into a warning on 2/1/23
-        console.warn(`Impossible situation: requested window ${downsampledRangeStart}-${downsampledRangeEnd} does not fit in canvas width ${canvas.width} as allowed by current scale factor ${scale}`)
-        // throw Error(`Impossible situation: requested window ${downsampledRangeStart}-${downsampledRangeEnd} does not fit in canvas width ${canvas.width} as allowed by current scale factor ${scale}`)
+    if ((Math.min(downsampledRangeEnd, downsampledRangeMax) - downsampledRangeStart) > (canvas.width)) {
+        throw Error(`Impossible situation: requested window ${downsampledRangeStart}-${downsampledRangeEnd} does not fit in canvas width ${canvas.width} as allowed by current scale factor ${scale}`)
     }
 
     // Request can be served from cache--do so


### PR DESCRIPTION
Addresses issue #16.

This PR reinstates the hard failure when the canvas is too narrow to display at least one pixel per downsampled data point in the 1d decode view, and fixes an issue where the actual position overlay would not display correctly when the 1d decode view was showing a region where there was no more decoded data. (In this instance, the position overlay data would be stretched over the entire canvas width, even though the decode data had run out.)

To do this, I've implemented logic in the dimension computation (for downsampled decode data) to record the end of the data series. Previously, that dimension computation was based on the visible window: we'd assume all of the data implied by that time range was visible and present, then use the downsampling process to convert the time points into indices of the downsampled data set. I've added to this a computation that figures out the index (at the current downsampling scale) that would correspond to the last actual data point.

The result is that the canvas width check can now use the width of the (converted) visible time, but cap it at the width of the data that exists. Since this no longer creates a spurious error when the time range implies too many data points for the offscreen canvas, I've reinstituted the hard error so that the next time there's a problem, we'll be made aware of it.

The other issue was that the actual-position overlay didn't respect the end of the decode data, because (again) there are no timestamps once the downsampling has occurred--instead the code to draw the observed position just scaled the visible data to the width of the panel. I've now made that depend on the proportion of the panel width which corresponds to actually-existing data, so that we'll no longer stretch the actual position over the entire canvas, like butter over too much bread.